### PR TITLE
Migrate to GH pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Notes on Git and GitHub
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/acc2c4d6-8f51-4092-8a87-5defa52f7e54/deploy-status)](https://app.netlify.com/sites/notes-on-git-and-github/deploys)
-
 Personal notes on what I've learned so far about the use of Git and GitHub. Use at your own risk. Issues and PRs
 welcome!


### PR DESCRIPTION
Turns out migrating to GH pages is just a matter of a few clicks in the Settings section. This PR is just removing the Netlify badge from the readme.